### PR TITLE
A few improvements to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,16 +6,12 @@ cmake_minimum_required(VERSION 3.1)
 # The project name.
 project(s3-demo)
 
-set(AWSSDK_ROOT_DIR, "/usr/local/")
-set(BUILD_SHARED_LIBS ON)
-
-
 # Locate the AWS SDK for C++ package.
-# Requires that you build with:
-#   -Daws-sdk-cpp_DIR=/path/to/sdk_build
-# or export/set:
-#   CMAKE_PREFIX_PATH=/path/to/sdk_build
-find_package(AWSSDK REQUIRED COMPONENTS s3)
+#
+# If the SDK was installed to a specific directory (e.g. by specifying -DCMAKE_INSTALL_PREFIX=/where/it/is
+# when building the SDK), then this project should be built with -DCMAKE_PREFIX_PATH=/where/it/is
+#
+find_package(AWSSDK REQUIRED s3)
 
 # Make binary globally available
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY /usr/local/bin)


### PR DESCRIPTION
- Setting `AWSSDK_ROOT_DIR` [isn't necessary](https://github.com/aws/aws-sdk-cpp/blob/4434d829c9c9e32a42e05bca637a258d9d9c6fcb/cmake/AWSSDKConfig.cmake#L9)
- `BUILD_SHARED_LIBS` is for building libraries as shared objects
- `REQUIRES` [implies](https://cmake.org/cmake/help/latest/command/find_package.html) `COMPONENTS` if there's a list after it

From the CMake docs:

> As a form of shorthand, if the `REQUIRED` option is present, the `COMPONENTS` keyword can be omitted and the required components can be listed directly after `REQUIRED`.